### PR TITLE
use repos under nodenv rather than OiNutter

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -120,7 +120,7 @@ define nodenv::build (
     cwd     => "${install_dir}/plugins/node-build",
     user    => 'root',
     unless  => "test -d ${install_dir}/versions/${title}",
-    require => Nodenv::Plugin['OiNutter/node-build'],
+    require => Nodenv::Plugin['nodenv/node-build'],
   }->
   exec { "nodenv-install-${title}":
     # patch file must be read from stdin only if supplied

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@
 # Copyright 2013 Justin Downing
 #
 class nodenv (
-  $repo_path   = 'https://github.com/OiNutter/nodenv.git',
+  $repo_path   = 'https://github.com/nodenv/nodenv.git',
   $install_dir = '/usr/local/nodenv',
   $owner       = 'root',
   $group       = $nodenv::deps::group,


### PR DESCRIPTION
[nodenv](https://github.com/nodenv/nodenv) and [node-build](https://github.com/nodenv/node-build) are maintained in the nodenv org now. 